### PR TITLE
Gather & upload artifacts to the update server

### DIFF
--- a/src/desktop_develop.js
+++ b/src/desktop_develop.js
@@ -214,7 +214,7 @@ class DesktopDevelopBuilder {
         const cfg = JSON.parse(await fsProm.readFile(path.join(repoDir, 'package.json'))).build;
 
         // the windows packager relies on parsing this as semver, so we have
-        // to make it looks like one. This will give our update packages really
+        // to make it look like one. This will give our update packages really
         // stupid names but we probably can't change that either because squirrel
         // windows parses them for the version too. We don't really care: nobody
         // sees them. We just give the installer a static name, so you'll just

--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,8 @@ const winVmName = process.env.RIOTBUILD_WIN_VMNAME;
 const winUsername = process.env.RIOTBUILD_WIN_USERNAME;
 const winPassword = process.env.RIOTBUILD_WIN_PASSWORD;
 
+const rsyncServer = process.env.RIOTBUILD_RSYNC_ROOT;
+
 if (
     winVmName === undefined ||
     winUsername === undefined ||
@@ -42,5 +44,10 @@ if (
     process.exit(1);
 }
 
-const desktopDevelopBuilder = new DesktopDevelopBuilder(winVmName, winUsername, winPassword);
+if (rsyncServer === undefined) {
+    console.error("rsync server not set: define RIOTBUILD_RSYNC_ROOT");
+    process.exit(1);
+}
+
+const desktopDevelopBuilder = new DesktopDevelopBuilder(winVmName, winUsername, winPassword, rsyncServer);
 desktopDevelopBuilder.start();


### PR DESCRIPTION
Accumulates update & install packages in a directory and rsyncs that directory up to the server. Pulls a debian repo down from the server, adds the new deb to it and then rsyncs it back up again.

NB. None of this currently prunes old versions from either the build server or the download server.

https://github.com/vector-im/riot-web/issues/12452