### PR TITLE
Prune mac & windows builds

### DIFF
--- a/src/desktop_develop.js
+++ b/src/desktop_develop.js
@@ -33,7 +33,7 @@ const TYPES = ['win64', 'mac', 'linux'];
 
 const DESKTOP_GIT_REPO = 'https://github.com/vector-im/riot-desktop.git';
 const ELECTRON_BUILDER_CFG_FILE = 'electron-builder.json';
-const KEEP_BUILDS_NUM = 7; // we keep a week's worth of nightly builds
+const KEEP_BUILDS_NUM = 14; // we keep two week's worth of nightly builds
 
 // take a date object and advance it to 9am the next morning
 function getNextBuildTime(d) {

--- a/src/desktop_develop.js
+++ b/src/desktop_develop.js
@@ -366,7 +366,7 @@ class DesktopDevelopBuilder {
             }
             await fsProm.writeFile(path.join(this.appPubDir, 'update', 'macos', 'latest'), buildVersion);
 
-            // prune update packages (the installer we just overwrite each time)
+            // prune update packages (the installer will just overwrite each time)
             await pruneBuilds(path.join(this.appPubDir, 'update', 'macos'), /-mac.zip$/);
         } else if (type === 'linux') {
             await pullDebDatabase(this.debDir, this.rsyncRoot);


### PR DESCRIPTION
Enables --delete on the artifact push which is a little scary but
obviously necessary to make the builds actually delete from the build
server.