### PR TITLE
Build at 8am so it's ready for when people wake up

### DIFF
--- a/src/desktop_develop.js
+++ b/src/desktop_develop.js
@@ -38,7 +38,7 @@ const KEEP_BUILDS_NUM = 14; // we keep two week's worth of nightly builds
 // take a date object and advance it to 9am the next morning
 function getNextBuildTime(d) {
     const next = new Date(d.getTime());
-    next.setHours(9);
+    next.setHours(8);
     next.setMinutes(0);
     next.setSeconds(0);
     next.setMilliseconds(0);


### PR DESCRIPTION
Accepting that if we ship a bad build, it'll take longer for people
to be around to fix it.