### PR TITLE
Replace Riot with Element in docs and comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "riot-builder",
+  "name": "element-builder",
   "version": "0.0.1",
-  "description": "A very minimal auto-builder for Riot",
+  "description": "A very minimal auto-builder for Element",
   "main": "src/index.js",
   "license": "Apache-2.0",
   "scripts": {

--- a/src/desktop_develop.js
+++ b/src/desktop_develop.js
@@ -291,7 +291,7 @@ class DesktopDevelopBuilder {
         const cfg = pkg.build;
 
         // Electron crashes on debian if there's a space in the path.
-        // https://github.com/vector-im/riot-web/issues/13171
+        // https://github.com/vector-im/element-web/issues/13171
         const productName = (type === 'linux') ? 'Element-Nightly' : 'Element Nightly';
 
         // the windows packager relies on parsing this as semver, so we have

--- a/src/desktop_release.js
+++ b/src/desktop_release.js
@@ -214,7 +214,7 @@ class DesktopReleaseBuilder {
         const cfg = pkg.build;
 
         // Electron crashes on debian if there's a space in the path.
-        // https://github.com/vector-im/riot-web/issues/13171
+        // https://github.com/vector-im/element-web/issues/13171
         const productName = (type === 'linux') ? 'Element' : pkg.productName;
 
         Object.assign(cfg, {


### PR DESCRIPTION
This only covers the simple cases of references to issues and repos. More
complex areas, such as deployment scripts, will be handled separately.

Part of https://github.com/vector-im/element-web/issues/14864