### PR TITLE
Catch artifact sync errors

### DIFF
--- a/src/desktop_develop.js
+++ b/src/desktop_develop.js
@@ -279,6 +279,12 @@ class DesktopDevelopBuilder {
             logger.info("Built packages for: " + toBuild.join(', ') + ": pushing packages...");
             await pushArtifacts(this.pubDir, this.rsyncRoot);
             logger.info("...push complete!");
+        } catch (e) {
+            logger.error("Artifact sync failed!", e);
+            // Mark all types as failed if artifact sync fails
+            for (const type of toBuild) {
+                this.lastFailTimes[type] = Date.now();
+            }
         } finally {
             this.building = false;
         }

--- a/src/desktop_release.js
+++ b/src/desktop_release.js
@@ -202,6 +202,8 @@ class DesktopReleaseBuilder {
             logger.info("Built packages for: " + toBuild.join(', ') + ": pushing packages...");
             await pushArtifacts(this.pubDir, this.rsyncRoot);
             logger.info("...push complete!");
+        } catch (e) {
+            logger.error("Artifact sync failed!", e);
         } finally {
             this.building = false;
         }


### PR DESCRIPTION
If artifact sync fails (e.g. due to internet connection issues), an unhandled rejection occurs, which causes Node to exit. This changes to catch those exceptions, so we can retry again in the future without manual intervention.