### PR TITLE
Fix GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
     push:
-        branches: [$default-branch]
+        branches: [main]
     pull_request:
-        branches: [$default-branch]
+        branches: [main]
 
 jobs:
     build:


### PR DESCRIPTION
`$default-branch` only works in a workflow template. In a concrete workflow, you have to use the actual branch.