### PR TITLE
Add Apple silicon support to nightly builds

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,10 @@ module.exports = {
     extends: [
         "plugin:matrix-org/typescript",
     ],
+    parserOptions: {
+        tsconfigRootDir: __dirname,
+        project: ["./tsconfig.json"],
+    },
     env: {
         node: true,
     },
@@ -12,6 +16,9 @@ module.exports = {
         // We aren't using ES modules here yet
         "@typescript-eslint/no-var-requires": "off",
 
+        // Ensure we always explicitly access string representations
+        "@typescript-eslint/no-base-to-string": "error",
+
         "quotes": "off",
-    }
+    },
 };

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /builds
+/lib

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "lint": "yarn lint:types && yarn lint:js",
     "lint:js": "eslint src",
-    "lint:types": "tsc --noEmit"
+    "lint:types": "tsc --noEmit",
+    "build": "tsc"
   },
   "dependencies": {
     "rimraf": "^3.0.2"

--- a/src/desktop_develop.ts
+++ b/src/desktop_develop.ts
@@ -434,10 +434,10 @@ export default class DesktopDevelopBuilder {
         target: Target,
     ): Promise<void> {
         await runner.run('yarn', 'install');
-        await runner.run('yarn', 'run', 'hak', 'check');
-        await runner.run('yarn', 'run', 'build:native');
+        await runner.run('yarn', 'run', 'hak', 'check', '--target', target.id);
+        await runner.run('yarn', 'run', 'build:native', '--target', target.id);
         await runner.run('yarn', 'run', 'fetch', 'develop', '-d', 'element.io/nightly');
-        await runner.run('yarn', 'build', '--config', ELECTRON_BUILDER_CFG_FILE);
+        await runner.run('yarn', 'build', `--${target.arch}`, '--config', ELECTRON_BUILDER_CFG_FILE);
     }
 
     private async buildWin(target: WindowsTarget, buildVersion: string): Promise<void> {
@@ -462,19 +462,17 @@ export default class DesktopDevelopBuilder {
         await builder.start();
         logger.info("...builder started");
 
-        const electronBuilderArchFlag = `--${target.arch}`;
-
         try {
             builder.appendScript('rd', buildDirName, '/s', '/q');
             builder.appendScript('git', 'clone', DESKTOP_GIT_REPO, buildDirName);
             builder.appendScript('cd', buildDirName);
             builder.appendScript('copy', 'z:\\' + ELECTRON_BUILDER_CFG_FILE, ELECTRON_BUILDER_CFG_FILE);
             builder.appendScript('call', 'yarn', 'install');
-            builder.appendScript('call', 'yarn', 'run', 'hak', 'check');
-            builder.appendScript('call', 'yarn', 'run', 'build:native');
+            builder.appendScript('call', 'yarn', 'run', 'hak', 'check', '--target', target.id);
+            builder.appendScript('call', 'yarn', 'run', 'build:native', '--target', target.id);
             builder.appendScript('call', 'yarn', 'run', 'fetch', 'develop', '-d', 'element.io\\nightly');
             builder.appendScript(
-                'call', 'yarn', 'build', electronBuilderArchFlag, '--config', ELECTRON_BUILDER_CFG_FILE,
+                'call', 'yarn', 'build', `--${target.arch}`, '--config', ELECTRON_BUILDER_CFG_FILE,
             );
             builder.appendScript('xcopy dist z:\\dist /S /I /Y');
             builder.appendScript('cd', '..');

--- a/src/desktop_develop.ts
+++ b/src/desktop_develop.ts
@@ -28,31 +28,7 @@ import Runner, { IRunner } from './runner';
 import DockerRunner from './docker_runner';
 
 import WindowsBuilder from './windows_builder';
-
-// TODO: Expand this to a multi-level type with platform and arch.
-const enum Type {
-    Windows32 = 'win32',
-    Windows64 = 'win64',
-    macOS = 'mac',
-    Linux = 'linux',
-}
-
-function isWindows(type: Type): boolean {
-    switch (type) {
-        case Type.Windows32:
-        case Type.Windows64:
-            return true;
-        default:
-            return false;
-    }
-}
-
-// The set of types we build by default
-const TYPES: Type[] = [
-    Type.Windows64,
-    Type.macOS,
-    Type.Linux,
-];
+import { ENABLED_TARGETS, Target, TargetId, WindowsTarget } from './target';
 
 const DESKTOP_GIT_REPO = 'https://github.com/vector-im/element-desktop.git';
 const ELECTRON_BUILDER_CFG_FILE = 'electron-builder.json';
@@ -73,20 +49,20 @@ function getNextBuildTime(d: Date): Date {
     return next;
 }
 
-async function getLastBuildTime(type: Type): Promise<number> {
+async function getLastBuildTime(target: Target): Promise<number> {
     try {
-        return parseInt(await fsProm.readFile('desktop_develop_lastBuilt_' + type, 'utf8'));
+        return parseInt(await fsProm.readFile('desktop_develop_lastBuilt_' + target.id, 'utf8'));
     } catch (e) {
-        logger.error(`Unable to read last build time for ${type}`, e);
+        logger.error(`Unable to read last build time for ${target.id}`, e);
         return 0;
     }
 }
 
-async function putLastBuildTime(type: Type, t: number): Promise<void> {
+async function putLastBuildTime(target: Target, t: number): Promise<void> {
     try {
-        await fsProm.writeFile('desktop_develop_lastBuilt_' + type, t.toString());
+        await fsProm.writeFile('desktop_develop_lastBuilt_' + target.id, t.toString());
     } catch (e) {
-        logger.error(`Unable to write last build time for ${type}`, e);
+        logger.error(`Unable to write last build time for ${target.id}`, e);
     }
 }
 
@@ -241,8 +217,8 @@ export default class DesktopDevelopBuilder {
     private appPubDir = path.join(this.pubDir, 'nightly');
     private building = false;
     private riotSigningKeyContainer: string;
-    private lastBuildTimes: Partial<Record<Type, number>> = {};
-    private lastFailTimes: Partial<Record<Type, number>> = {};
+    private lastBuildTimes: Partial<Record<TargetId, number>> = {};
+    private lastFailTimes: Partial<Record<TargetId, number>> = {};
 
     constructor(
         private winVmName: string,
@@ -265,9 +241,9 @@ export default class DesktopDevelopBuilder {
 
         this.lastBuildTimes = {};
         this.lastFailTimes = {};
-        for (const type of TYPES) {
-            this.lastBuildTimes[type] = await getLastBuildTime(type);
-            this.lastFailTimes[type] = 0;
+        for (const target of ENABLED_TARGETS) {
+            this.lastBuildTimes[target.id] = await getLastBuildTime(target);
+            this.lastFailTimes[target.id] = 0;
         }
 
         setInterval(this.poll, 30 * 1000);
@@ -277,14 +253,14 @@ export default class DesktopDevelopBuilder {
     private poll = async (): Promise<void> => {
         if (this.building) return;
 
-        const toBuild: Type[] = [];
-        for (const type of TYPES) {
+        const toBuild: Target[] = [];
+        for (const target of ENABLED_TARGETS) {
             const nextBuildDue = getNextBuildTime(new Date(Math.max(
-                this.lastBuildTimes[type], this.lastFailTimes[type],
+                this.lastBuildTimes[target.id], this.lastFailTimes[target.id],
             )));
             //logger.debug("Next build due at " + nextBuildDue);
             if (nextBuildDue.getTime() < Date.now()) {
-                toBuild.push(type);
+                toBuild.push(target);
             }
         }
 
@@ -296,30 +272,30 @@ export default class DesktopDevelopBuilder {
             // Sync all the artifacts from the server before we start
             await pullArtifacts(this.pubDir, this.rsyncRoot);
 
-            for (const type of toBuild) {
+            for (const target of toBuild) {
                 try {
-                    logger.info("Starting build of " + type);
+                    logger.info("Starting build of " + target.id);
                     const thisBuildVersion = getBuildVersion();
-                    await this.build(type, thisBuildVersion);
-                    this.lastBuildTimes[type] = Date.now();
-                    await putLastBuildTime(type, this.lastBuildTimes[type]);
+                    await this.build(target, thisBuildVersion);
+                    this.lastBuildTimes[target.id] = Date.now();
+                    await putLastBuildTime(target, this.lastBuildTimes[target.id]);
                 } catch (e) {
                     logger.error("Build failed!", e);
-                    this.lastFailTimes[type] = Date.now();
+                    this.lastFailTimes[target.id] = Date.now();
                     // if one fails, bail out of the whole process: probably better
                     // to have all platforms not updating than just one
                     return;
                 }
             }
 
-            logger.info("Built packages for: " + toBuild.join(', ') + ": pushing packages...");
+            logger.info("Built packages for: " + toBuild.map(t => t.id).join(', ') + ": pushing packages...");
             await pushArtifacts(this.pubDir, this.rsyncRoot);
             logger.info("...push complete!");
         } catch (e) {
             logger.error("Artifact sync failed!", e);
             // Mark all types as failed if artifact sync fails
-            for (const type of toBuild) {
-                this.lastFailTimes[type] = Date.now();
+            for (const target of toBuild) {
+                this.lastFailTimes[target.id] = Date.now();
             }
         } finally {
             this.building = false;
@@ -327,7 +303,7 @@ export default class DesktopDevelopBuilder {
     }
 
     private async writeElectronBuilderConfigFile(
-        type: Type,
+        target: Target,
         repoDir: string,
         buildVersion: string,
     ): Promise<void> {
@@ -338,7 +314,7 @@ export default class DesktopDevelopBuilder {
 
         // Electron crashes on debian if there's a space in the path.
         // https://github.com/vector-im/element-web/issues/13171
-        const productName = type === Type.Linux ? 'Element-Nightly' : 'Element Nightly';
+        const productName = target.platform === 'linux' ? 'Element-Nightly' : 'Element Nightly';
 
         // the windows packager relies on parsing this as semver, so we have
         // to make it look like one. This will give our update packages really
@@ -347,7 +323,7 @@ export default class DesktopDevelopBuilder {
         // sees them. We just give the installer a static name, so you'll just
         // see this in the 'about' dialog.
         // Turns out if you use 0.0.0 here it makes Squirrel windows crash, so we use 0.0.1.
-        const version = isWindows(type) ? '0.0.1-nightly.' + buildVersion : buildVersion;
+        const version = target.platform === 'win32' ? '0.0.1-nightly.' + buildVersion : buildVersion;
 
         Object.assign(cfg, {
             // We override a lot of the metadata for the nightly build
@@ -369,25 +345,25 @@ export default class DesktopDevelopBuilder {
         );
     }
 
-    private async build(type: Type, buildVersion: string): Promise<void> {
-        if (isWindows(type)) {
-            return this.buildWin(type, buildVersion);
+    private async build(target: Target, buildVersion: string): Promise<void> {
+        if (target.platform === 'win32') {
+            return this.buildWin(target as WindowsTarget, buildVersion);
         } else {
-            return this.buildLocal(type, buildVersion);
+            return this.buildLocal(target, buildVersion);
         }
     }
 
-    private async buildLocal(type: Type, buildVersion: string): Promise<void> {
+    private async buildLocal(target: Target, buildVersion: string): Promise<void> {
         await fsProm.mkdir('builds', { recursive: true });
-        const repoDir = path.join('builds', 'element-desktop-' + type + '-' + buildVersion);
+        const repoDir = path.join('builds', 'element-desktop-' + target.id + '-' + buildVersion);
         await rm(repoDir);
         logger.info("Cloning element-desktop into " + repoDir);
         const repo = new GitRepo(repoDir);
         await repo.clone(DESKTOP_GIT_REPO, repoDir);
-        logger.info("...checked out 'develop' branch, starting build for " + type);
+        logger.info("...checked out 'develop' branch, starting build for " + target.id);
 
-        await this.writeElectronBuilderConfigFile(type, repoDir, buildVersion);
-        if (type === Type.Linux) {
+        await this.writeElectronBuilderConfigFile(target, repoDir, buildVersion);
+        if (target.platform === 'linux') {
             await setDebVersion(
                 buildVersion,
                 path.join(repoDir, 'element.io', 'nightly', 'control.template'),
@@ -396,21 +372,21 @@ export default class DesktopDevelopBuilder {
         }
 
         let runner: IRunner;
-        switch (type) {
-            case Type.macOS:
+        switch (target.platform) {
+            case 'darwin':
                 runner = this.makeMacRunner(repoDir);
                 break;
-            case Type.Linux:
+            case 'linux':
                 runner = this.makeLinuxRunner(repoDir);
                 break;
             default:
-                throw new Error(`Unexpected local type ${type}`);
+                throw new Error(`Unexpected local target ${target.id}`);
         }
 
-        await this.buildWithRunner(runner, buildVersion, type);
+        await this.buildWithRunner(runner, buildVersion, target);
         logger.info("Build completed!");
 
-        if (type === Type.macOS) {
+        if (target.platform === 'darwin') {
             await fsProm.mkdir(path.join(this.appPubDir, 'install', 'macos'), { recursive: true });
             await fsProm.mkdir(path.join(this.appPubDir, 'update', 'macos'), { recursive: true });
 
@@ -432,7 +408,7 @@ export default class DesktopDevelopBuilder {
 
             // prune update packages (the installer will just overwrite each time)
             await pruneBuilds(path.join(this.appPubDir, 'update', 'macos'), /-mac.zip$/);
-        } else if (type === Type.Linux) {
+        } else if (target.platform === 'linux') {
             await pullDebDatabase(this.debDir, this.rsyncRoot);
             for (const f of await getMatchingFilesInDir(path.join(repoDir, 'dist'), /\.deb$/)) {
                 await addDeb(this.debDir, path.resolve(repoDir, 'dist', f));
@@ -455,7 +431,7 @@ export default class DesktopDevelopBuilder {
     private async buildWithRunner(
         runner: IRunner,
         buildVersion: string,
-        type: Type,
+        target: Target,
     ): Promise<void> {
         await runner.run('yarn', 'install');
         await runner.run('yarn', 'run', 'hak', 'check');
@@ -464,9 +440,9 @@ export default class DesktopDevelopBuilder {
         await runner.run('yarn', 'build', '--config', ELECTRON_BUILDER_CFG_FILE);
     }
 
-    private async buildWin(type: Type, buildVersion: string): Promise<void> {
+    private async buildWin(target: WindowsTarget, buildVersion: string): Promise<void> {
         await fsProm.mkdir('builds', { recursive: true });
-        const buildDirName = 'element-desktop-' + type + '-' + buildVersion;
+        const buildDirName = 'element-desktop-' + target.id + '-' + buildVersion;
         const repoDir = path.join('builds', buildDirName);
         await rm(repoDir);
 
@@ -476,17 +452,17 @@ export default class DesktopDevelopBuilder {
         const repo = new GitRepo(repoDir);
         await repo.clone(DESKTOP_GIT_REPO, repoDir);
         //await fsProm.mkdir(repoDir);
-        await this.writeElectronBuilderConfigFile(type, repoDir, buildVersion);
+        await this.writeElectronBuilderConfigFile(target, repoDir, buildVersion);
 
         const builder = new WindowsBuilder(
-            repoDir, type, this.winVmName, this.winUsername, this.winPassword, this.riotSigningKeyContainer,
+            repoDir, target, this.winVmName, this.winUsername, this.winPassword, this.riotSigningKeyContainer,
         );
 
-        logger.info("Starting Windows builder for " + type + '...');
+        logger.info("Starting Windows builder for " + target.id + '...');
         await builder.start();
         logger.info("...builder started");
 
-        const electronBuilderArchFlag = type === Type.Windows64 ? '--x64' : '--ia32';
+        const electronBuilderArchFlag = `--${target.arch}`;
 
         try {
             builder.appendScript('rd', buildDirName, '/s', '/q');
@@ -508,8 +484,8 @@ export default class DesktopDevelopBuilder {
             await builder.runScript();
             logger.info("Build complete!");
 
-            const squirrelDir = 'squirrel-windows' + (type === Type.Windows32 ? '-ia32' : '');
-            const archDir = type === Type.Windows32 ? 'ia32' : 'x64';
+            const squirrelDir = 'squirrel-windows' + (target.arch === 'ia32' ? '-ia32' : '');
+            const archDir = target.arch;
 
             await fsProm.mkdir(path.join(this.appPubDir, 'install', 'win32', archDir), { recursive: true });
             await fsProm.mkdir(path.join(this.appPubDir, 'update', 'win32', archDir), { recursive: true });

--- a/src/target.ts
+++ b/src/target.ts
@@ -93,3 +93,18 @@ export const ENABLED_TARGETS: Target[] = [
     TARGETS['x86_64-unknown-linux-gnu'],
     TARGETS['i686-pc-windows-msvc'],
 ];
+
+export function getHost(): Target {
+    return Object.values(TARGETS).find(target => (
+        target.platform === process.platform &&
+        target.arch === process.arch
+    ));
+}
+
+export function isHostId(id: TargetId): boolean {
+    return getHost()?.id === id;
+}
+
+export function isHost(target: Target): boolean {
+    return getHost()?.id === target.id;
+}

--- a/src/target.ts
+++ b/src/target.ts
@@ -77,7 +77,7 @@ const x8664UnknownLinuxGnu: Target = {
     arch: 'x64',
 };
 
-const TARGETS: Record<TargetId, Target> = {
+export const TARGETS: Record<TargetId, Target> = {
     'aarch64-apple-darwin': aarch64AppleDarwin,
     'i686-pc-windows-msvc': i686PcWindowsMsvc,
     'x86_64-pc-windows-msvc': x8664PcWindowsMsvc,

--- a/src/target.ts
+++ b/src/target.ts
@@ -1,0 +1,95 @@
+/*
+Copyright 2021 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// We borrow Rust's target naming scheme as a way of expressing all target
+// details in a single string.
+// See https://doc.rust-lang.org/rustc/platform-support.html.
+export type TargetId =
+    'aarch64-apple-darwin' |
+    'i686-pc-windows-msvc' |
+    'x86_64-pc-windows-msvc' |
+    'x86_64-apple-darwin' |
+    'x86_64-unknown-linux-gnu';
+
+// Values are expected to match those used in `process.platform`.
+type Platform = 'darwin' | 'linux' | 'win32';
+
+// Values are expected to match those used in `process.arch`.
+type Arch = 'arm64' | 'ia32' | 'x64';
+
+// Values are expected to match those used by Visual Studio's `vcvarsall.bat`.
+// See https://docs.microsoft.com/cpp/build/building-on-the-command-line?view=msvc-160#vcvarsall-syntax
+type VcVarsArch = 'amd64' | 'arm64' | 'x86';
+
+export type Target = {
+    id: TargetId;
+    platform: Platform;
+    arch: Arch;
+}
+
+export type WindowsTarget = Target & {
+    platform: 'win32';
+    vcVarsArch: VcVarsArch;
+}
+
+const aarch64AppleDarwin: Target = {
+    id: 'aarch64-apple-darwin',
+    platform: 'darwin',
+    arch: 'arm64',
+};
+
+const i686PcWindowsMsvc: WindowsTarget = {
+    id: 'i686-pc-windows-msvc',
+    platform: 'win32',
+    arch: 'ia32',
+    vcVarsArch: 'x86',
+}
+
+const x8664PcWindowsMsvc: WindowsTarget = {
+    id: 'x86_64-pc-windows-msvc',
+    platform: 'win32',
+    arch: 'x64',
+    vcVarsArch: 'amd64',
+}
+
+const x8664AppleDarwin: Target = {
+    id: 'x86_64-apple-darwin',
+    platform: 'darwin',
+    arch: 'x64',
+};
+
+const x8664UnknownLinuxGnu: Target = {
+    id: 'x86_64-unknown-linux-gnu',
+    platform: 'linux',
+    arch: 'x64',
+};
+
+const TARGETS: Record<TargetId, Target> = {
+    'aarch64-apple-darwin': aarch64AppleDarwin,
+    'i686-pc-windows-msvc': i686PcWindowsMsvc,
+    'x86_64-pc-windows-msvc': x8664PcWindowsMsvc,
+    'x86_64-apple-darwin': x8664AppleDarwin,
+    'x86_64-unknown-linux-gnu': x8664UnknownLinuxGnu,
+};
+
+// The set of targets we build by default, sorted by increasing complexity so
+// that we fail fast when the native host target fails.
+export const ENABLED_TARGETS: Target[] = [
+    TARGETS['x86_64-apple-darwin'],
+    TARGETS['aarch64-apple-darwin'],
+    TARGETS['x86_64-unknown-linux-gnu'],
+    TARGETS['i686-pc-windows-msvc'],
+];

--- a/src/windows_builder.ts
+++ b/src/windows_builder.ts
@@ -19,6 +19,7 @@ import { promises as fsProm } from 'fs';
 import * as childProcess from 'child_process';
 
 import logger from './logger';
+import { WindowsTarget } from './target';
 
 const STARTVM_TIMEOUT = 90 * 1000;
 const POWEROFF_TIMEOUT = 20 * 1000;
@@ -40,7 +41,7 @@ export default class WindowsBuilder {
 
     constructor(
         private cwd: string,
-        private arch: string,
+        private target: WindowsTarget,
         private vmName: string,
         private username: string,
         private password: string,
@@ -162,7 +163,7 @@ export default class WindowsBuilder {
 
     public async runScript(): Promise<void> {
         const tmpCmdFile = path.join(this.cwd, 'tmp.cmd');
-        const vcvarsArch = this.arch === 'win64' ? 'amd64' : 'x86';
+        const vcvarsArch = this.target.vcVarsArch;
         const fileContents = (
             "echo on\r\n" +
             "call \"" + VCVARSALL + '" ' + vcvarsArch + '\r\n' +

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "target": "es2020",
+        "outDir": "./lib",
     },
     "include": [
         ".eslintrc.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
         "target": "es2020",
     },
     "include": [
+        ".eslintrc.js",
         "./src/**/*.ts",
     ]
 }


### PR DESCRIPTION
This updates the nightly builds to additionally build for Apple silicon.

A new `Target` type is used to handle the various ways of specifying platforms and architectures. This is also shared with `element-desktop` via https://github.com/vector-im/element-desktop/pull/216, though a package seemed like a lot of trouble for one file that will rarely change, so this includes a build step that can be used to produce a JS copy of the target module, in case changes are needed.

Part of https://github.com/vector-im/element-web/issues/16075
Related to https://github.com/vector-im/element-desktop/pull/216