### PR TITLE
Add types and Apple silicon support to release builder

### DIFF
--- a/src/artifacts.ts
+++ b/src/artifacts.ts
@@ -17,6 +17,8 @@ limitations under the License.
 import * as childProcess from 'child_process';
 import { promises as fsProm } from 'fs';
 
+import * as rimraf from 'rimraf';
+
 import logger from './logger';
 
 export async function getMatchingFilesInDir(dir: string, exp: RegExp): Promise<string[]> {
@@ -63,4 +65,12 @@ export function pushArtifacts(pubDir: string, rsyncRoot: string): Promise<void> 
 export function copyAndLog(src: string, dest: string): Promise<void> {
     logger.info('Copy ' + src + ' -> ' + dest);
     return fsProm.copyFile(src, dest);
+}
+
+export function rm(path: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+        rimraf(path, (err) => {
+            err ? reject(err) : resolve();
+        });
+    });
 }

--- a/src/artifacts.ts
+++ b/src/artifacts.ts
@@ -1,0 +1,66 @@
+/*
+Copyright 2021 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import * as childProcess from 'child_process';
+import { promises as fsProm } from 'fs';
+
+import logger from './logger';
+
+export async function getMatchingFilesInDir(dir: string, exp: RegExp): Promise<string[]> {
+    const ret = [];
+    for (const f of await fsProm.readdir(dir)) {
+        if (exp.test(f)) {
+            ret.push(f);
+        }
+    }
+    if (ret.length === 0) {
+        throw new Error("No files found matching " + exp.toString() + "!");
+    }
+    return ret;
+}
+
+export function pullArtifacts(pubDir: string, rsyncRoot: string): Promise<void> {
+    logger.info("Pulling artifacts...");
+    return new Promise((resolve, reject) => {
+        const proc = childProcess.spawn('rsync', [
+            '-av', '--delete', rsyncRoot + 'packages.riot.im/', pubDir,
+        ], {
+            stdio: 'inherit',
+        });
+        proc.on('exit', code => {
+            code ? reject(code) : resolve();
+        });
+    });
+}
+
+export function pushArtifacts(pubDir: string, rsyncRoot: string): Promise<void> {
+    logger.info("Uploading artifacts...");
+    return new Promise((resolve, reject) => {
+        const proc = childProcess.spawn('rsync', [
+            '-av', '--delete', '--delay-updates', pubDir + '/', rsyncRoot + 'packages.riot.im',
+        ], {
+            stdio: 'inherit',
+        });
+        proc.on('exit', code => {
+            code ? reject(code) : resolve();
+        });
+    });
+}
+
+export function copyAndLog(src: string, dest: string): Promise<void> {
+    logger.info('Copy ' + src + ' -> ' + dest);
+    return fsProm.copyFile(src, dest);
+}

--- a/src/debian.ts
+++ b/src/debian.ts
@@ -1,0 +1,88 @@
+/*
+Copyright 2021 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import * as childProcess from 'child_process';
+import { promises as fsProm } from 'fs';
+import * as path from 'path';
+
+import logger from './logger';
+
+async function getRepoTargets(repoDir: string): Promise<string[]> {
+    const confDistributions = await fsProm.readFile(path.join(repoDir, 'conf', 'distributions'), 'utf8');
+    const ret = [];
+    for (const line of confDistributions.split('\n')) {
+        if (line.startsWith('Codename')) {
+            ret.push(line.split(': ')[1]);
+        }
+    }
+    return ret;
+}
+
+export async function setDebVersion(ver: string, templateFile: string, outFile: string): Promise<void> {
+    // Create a debian package control file with the version.
+    // We use a custom control file so we need to do this ourselves
+    let contents = await fsProm.readFile(templateFile, 'utf8');
+    contents += 'Version: ' + ver + "\n";
+    await fsProm.writeFile(outFile, contents);
+
+    logger.info("Version set to " + ver);
+}
+
+export function pullDebDatabase(debDir: string, rsyncRoot: string): Promise<void> {
+    logger.info("Pulling debian database...", rsyncRoot + 'debian/', debDir);
+    return new Promise((resolve, reject) => {
+        const proc = childProcess.spawn('rsync', [
+            '-av', '--delete', rsyncRoot + 'debian/', debDir,
+        ], {
+            stdio: 'inherit',
+        });
+        proc.on('exit', code => {
+            code ? reject(code) : resolve();
+        });
+    });
+}
+
+export function pushDebDatabase(debDir: string, rsyncRoot: string): Promise<void> {
+    logger.info("Pushing debian database...");
+    return new Promise((resolve, reject) => {
+        const proc = childProcess.spawn('rsync', [
+            '-av', '--delete', debDir + '/', rsyncRoot + 'debian',
+        ], {
+            stdio: 'inherit',
+        });
+        proc.on('exit', code => {
+            code ? reject(code) : resolve();
+        });
+    });
+}
+
+export async function addDeb(debDir: string, deb: string): Promise<void> {
+    const targets = await getRepoTargets(debDir);
+    logger.info("Adding " + deb + " for " + targets.join(', ') + "...");
+    for (const target of targets) {
+        await new Promise<void>((resolve, reject) => {
+            const proc = childProcess.spawn('reprepro', [
+                'includedeb', target, deb,
+            ], {
+                stdio: 'inherit',
+                cwd: debDir,
+            });
+            proc.on('exit', code => {
+                code ? reject(code) : resolve();
+            });
+        });
+    }
+}

--- a/src/desktop_develop.ts
+++ b/src/desktop_develop.ts
@@ -17,8 +17,6 @@ limitations under the License.
 import { promises as fsProm } from 'fs';
 import * as path from 'path';
 
-import * as rimraf from 'rimraf';
-
 import getSecret from './get_secret';
 import GitRepo from './gitrepo';
 import logger from './logger';
@@ -27,7 +25,7 @@ import DockerRunner from './docker_runner';
 import WindowsBuilder from './windows_builder';
 import { ENABLED_TARGETS, Target, TargetId, WindowsTarget } from './target';
 import { setDebVersion, pullDebDatabase, pushDebDatabase, addDeb } from './debian';
-import { getMatchingFilesInDir, pullArtifacts, pushArtifacts, copyAndLog } from './artifacts';
+import { getMatchingFilesInDir, pullArtifacts, pushArtifacts, copyAndLog, rm } from './artifacts';
 
 const DESKTOP_GIT_REPO = 'https://github.com/vector-im/element-desktop.git';
 const ELECTRON_BUILDER_CFG_FILE = 'electron-builder.json';
@@ -87,14 +85,6 @@ async function pruneBuilds(dir: string, exp: RegExp): Promise<void> {
     for (const f of toDelete) {
         await fsProm.unlink(path.join(dir, f));
     }
-}
-
-function rm(path: string): Promise<void> {
-    return new Promise((resolve, reject) => {
-        rimraf(path, (err) => {
-            err ? reject(err) : resolve();
-        });
-    });
 }
 
 export default class DesktopDevelopBuilder {

--- a/src/desktop_release.ts
+++ b/src/desktop_release.ts
@@ -17,8 +17,6 @@ limitations under the License.
 import { promises as fsProm } from 'fs';
 import * as path from 'path';
 
-import * as rimraf from 'rimraf';
-
 import getSecret from './get_secret';
 import GitRepo from './gitrepo';
 import logger from './logger';
@@ -27,7 +25,7 @@ import DockerRunner from './docker_runner';
 import WindowsBuilder from './windows_builder';
 import { ENABLED_TARGETS, Target, TargetId, WindowsTarget } from './target';
 import { setDebVersion, pullDebDatabase, pushDebDatabase, addDeb } from './debian';
-import { getMatchingFilesInDir, pullArtifacts, pushArtifacts, copyAndLog } from './artifacts';
+import { getMatchingFilesInDir, pullArtifacts, pushArtifacts, copyAndLog, rm } from './artifacts';
 
 const DESKTOP_GIT_REPO = 'https://github.com/vector-im/element-desktop.git';
 const ELECTRON_BUILDER_CFG_FILE = 'electron-builder.json';
@@ -138,11 +136,7 @@ export default class DesktopReleaseBuilder {
     private async buildLocal(target: Target, buildVersion: string): Promise<void> {
         await fsProm.mkdir('builds', { recursive: true });
         const repoDir = path.join('builds', 'element-desktop-' + type + '-' + this.desktopBranch);
-        await new Promise((resolve, reject) => {
-            rimraf(repoDir, (err) => {
-                err ? reject(err) : resolve();
-            });
-        });
+        await rm(repoDir);
         logger.info("Cloning element-desktop into " + repoDir);
         const repo = new GitRepo(repoDir);
         // Clone element-desktop at tag / branch to build from, e.g. v1.6.0
@@ -206,11 +200,7 @@ export default class DesktopReleaseBuilder {
         }
 
         logger.info("Removing build dir");
-        await new Promise((resolve, reject) => {
-            rimraf(repoDir, (err) => {
-                err ? reject(err) : resolve();
-            });
-        });
+        await rm(repoDir);
     }
 
     private makeMacRunner(cwd: string): IRunner {
@@ -239,11 +229,7 @@ export default class DesktopReleaseBuilder {
         await fsProm.mkdir('builds', { recursive: true });
         const buildDirName = 'element-desktop-' + type + '-' + this.desktopBranch;
         const repoDir = path.join('builds', buildDirName);
-        await new Promise((resolve, reject) => {
-            rimraf(repoDir, (err) => {
-                err ? reject(err) : resolve();
-            });
-        });
+        await rm(repoDir);
 
         // we still check out the repo locally because we need package.json
         // to write the electron builder config file, so we check out the
@@ -327,10 +313,6 @@ export default class DesktopReleaseBuilder {
         }
 
         logger.info("Removing build dir");
-        await new Promise((resolve, reject) => {
-            rimraf(repoDir, (err) => {
-                err ? reject(err) : resolve();
-            });
-        });
+        await rm(repoDir);
     }
 }

--- a/src/desktop_release.ts
+++ b/src/desktop_release.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Matrix.org Foundation C.I.C.
+Copyright 2020-2021 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/desktop_release.ts
+++ b/src/desktop_release.ts
@@ -14,22 +14,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-const fsProm = require('fs').promises;
-const path = require('path');
-const childProcess = require('child_process');
+import { promises as fsProm } from 'fs';
+import * as path from 'path';
+import * as childProcess from 'child_process';
 
-const rimraf = require('rimraf');
+import * as rimraf from 'rimraf';
 
-const getSecret = require('./get_secret');
-const GitRepo = require('./gitrepo');
-const logger = require('./logger');
+import getSecret from './get_secret';
+import GitRepo from './gitrepo';
+import logger from './logger';
 
-const Runner = require('./runner');
-const DockerRunner = require('./docker_runner');
+import Runner, { IRunner } from './runner';
+import DockerRunner from './docker_runner';
 
-const WindowsBuilder = require('./windows_builder');
-
-const TYPES = ['win64', 'mac', 'linux'];
+import WindowsBuilder from './windows_builder';
+import { ENABLED_TARGETS, Target, TargetId, WindowsTarget } from './target';
 
 const DESKTOP_GIT_REPO = 'https://github.com/vector-im/element-desktop.git';
 const ELECTRON_BUILDER_CFG_FILE = 'electron-builder.json';

--- a/src/desktop_release.ts
+++ b/src/desktop_release.ts
@@ -16,133 +16,21 @@ limitations under the License.
 
 import { promises as fsProm } from 'fs';
 import * as path from 'path';
-import * as childProcess from 'child_process';
 
 import * as rimraf from 'rimraf';
 
 import getSecret from './get_secret';
 import GitRepo from './gitrepo';
 import logger from './logger';
-
 import Runner, { IRunner } from './runner';
 import DockerRunner from './docker_runner';
-
 import WindowsBuilder from './windows_builder';
 import { ENABLED_TARGETS, Target, TargetId, WindowsTarget } from './target';
+import { setDebVersion, pullDebDatabase, pushDebDatabase, addDeb } from './debian';
+import { getMatchingFilesInDir, pullArtifacts, pushArtifacts, copyAndLog } from './artifacts';
 
 const DESKTOP_GIT_REPO = 'https://github.com/vector-im/element-desktop.git';
 const ELECTRON_BUILDER_CFG_FILE = 'electron-builder.json';
-
-async function setDebVersion(ver, templateFile, outFile) {
-    // Create a debian package control file with the version.
-    // We use a custom control file so we need to do this ourselves
-    let contents = await fsProm.readFile(templateFile, 'utf8');
-    contents += 'Version: ' + ver + "\n";
-    await fsProm.writeFile(outFile, contents);
-
-    logger.info("Version set to " + ver);
-}
-
-async function getMatchingFilesInDir(dir, exp) {
-    const ret = [];
-    for (const f of await fsProm.readdir(dir)) {
-        if (exp.test(f)) {
-            ret.push(f);
-        }
-    }
-    if (ret.length === 0) throw new Error("No files found matching " + exp.toString() + "!");
-    return ret;
-}
-
-async function getRepoTargets(repoDir) {
-    const confDistributions = await fsProm.readFile(path.join(repoDir, 'conf', 'distributions'), 'utf8');
-    const ret = [];
-    for (const line of confDistributions.split('\n')) {
-        if (line.startsWith('Codename')) {
-            ret.push(line.split(': ')[1]);
-        }
-    }
-    return ret;
-}
-
-function pullDebDatabase(debDir, rsyncRoot) {
-    logger.info("Pulling debian database...", rsyncRoot + 'debian/', debDir);
-    return new Promise((resolve, reject) => {
-        const proc = childProcess.spawn('rsync', [
-            '-av', '--delete', rsyncRoot + 'debian/', debDir,
-        ], {
-            stdio: 'inherit',
-        });
-        proc.on('exit', code => {
-            code ? reject(code) : resolve();
-        });
-    });
-}
-
-function pushDebDatabase(debDir, rsyncRoot) {
-    logger.info("Pushing debian database...");
-    return new Promise((resolve, reject) => {
-        const proc = childProcess.spawn('rsync', [
-            '-av', '--delete', debDir + '/', rsyncRoot + 'debian',
-        ], {
-            stdio: 'inherit',
-        });
-        proc.on('exit', code => {
-            code ? reject(code) : resolve();
-        });
-    });
-}
-
-async function addDeb(debDir, deb) {
-    const targets = await getRepoTargets(debDir);
-    logger.info("Adding " + deb + " for " + targets.join(', ') + "...");
-    for (const target of targets) {
-        await new Promise((resolve, reject) => {
-            const proc = childProcess.spawn('reprepro', [
-                'includedeb', target, deb,
-            ], {
-                stdio: 'inherit',
-                cwd: debDir,
-            });
-            proc.on('exit', code => {
-                code ? reject(code) : resolve();
-            });
-        });
-    }
-}
-
-function pullArtifacts(pubDir, rsyncRoot) {
-    logger.info("Pulling artifacts...");
-    return new Promise((resolve, reject) => {
-        const proc = childProcess.spawn('rsync', [
-            '-av', '--delete', rsyncRoot + 'packages.riot.im/', pubDir,
-        ], {
-            stdio: 'inherit',
-        });
-        proc.on('exit', code => {
-            code ? reject(code) : resolve();
-        });
-    });
-}
-
-function pushArtifacts(pubDir, rsyncRoot) {
-    logger.info("Uploading artifacts...");
-    return new Promise((resolve, reject) => {
-        const proc = childProcess.spawn('rsync', [
-            '-av', '--delete', '--delay-updates', pubDir + '/', rsyncRoot + 'packages.riot.im',
-        ], {
-            stdio: 'inherit',
-        });
-        proc.on('exit', code => {
-            code ? reject(code) : resolve();
-        });
-    });
-}
-
-function copyAndLog(src, dest) {
-    logger.info('Copy ' + src + ' -> ' + dest);
-    return fsProm.copyFile(src, dest);
-}
 
 class DesktopReleaseBuilder {
     constructor(winVmName, winUsername, winPassword, rsyncRoot, desktopBranch) {

--- a/src/desktop_release.ts
+++ b/src/desktop_release.ts
@@ -32,21 +32,22 @@ import { getMatchingFilesInDir, pullArtifacts, pushArtifacts, copyAndLog } from 
 const DESKTOP_GIT_REPO = 'https://github.com/vector-im/element-desktop.git';
 const ELECTRON_BUILDER_CFG_FILE = 'electron-builder.json';
 
-class DesktopReleaseBuilder {
-    constructor(winVmName, winUsername, winPassword, rsyncRoot, desktopBranch) {
-        this.winVmName = winVmName;
-        this.winUsername = winUsername;
-        this.winPassword = winPassword;
-        this.rsyncRoot = rsyncRoot;
-        // This is the tag / branch of element-desktop to build from, e.g. v1.6.0
-        this.desktopBranch = desktopBranch;
+export default class DesktopReleaseBuilder {
+    private pubDir = path.join(process.cwd(), 'packages.riot.im');
+    // This should be a reprepro dir with a config redirecting
+    // the output to pub/debian
+    private debDir = path.join(process.cwd(), 'debian');
+    private appPubDir = path.join(this.pubDir, 'desktop');
+    private building = false;
+    private riotSigningKeyContainer: string;
 
-        this.pubDir = path.join(process.cwd(), 'packages.riot.im');
-        // This should be a reprepro dir with a config redirecting
-        // the output to pub/debian
-        this.debDir = path.join(process.cwd(), 'debian');
-        this.appPubDir = path.join(this.pubDir, 'desktop');
-    }
+    constructor(
+        private winVmName: string,
+        private winUsername: string,
+        private winPassword: string,
+        private rsyncRoot: string,
+        private desktopBranch: string,
+    ) { }
 
     async start() {
         logger.info(`Starting Element Desktop ${this.desktopBranch} release builder...`);
@@ -325,5 +326,3 @@ class DesktopReleaseBuilder {
         });
     }
 }
-
-module.exports = DesktopReleaseBuilder;


### PR DESCRIPTION
This brings the same enhancements recently added to develop over to the release builder as well.

In addition, some shared functions used by both builders have been extracted out to shared modules.

Part of https://github.com/vector-im/element-web/issues/17759