### PR TITLE
Don't pull either the artifacts or the deb database

### DIFF
--- a/src/artifacts.ts
+++ b/src/artifacts.ts
@@ -34,26 +34,6 @@ export async function getMatchingFilesInDir(dir: string, exp: RegExp): Promise<s
     return ret;
 }
 
-export function pullArtifacts(pubDir: string, rsyncRoot: string): Promise<void> {
-    logger.info("Pulling artifacts...");
-    return new Promise((resolve, reject) => {
-        const proc = childProcess.spawn('rsync', [
-            // NB. We don't pass --delete here so if we want to delete any files from the packaging server,
-            // we need to do so by deleting them on the build box copy and then letting the delete sync
-            // over, rather than deleting directly on the server, else they'll just sync back again.
-            // This is because we copy built artifacts directly into our copy of the repo after each
-            // one is built, so if a build fails, we'd delete the built artifact when we pulled the
-            // artifacts at next startup.
-            '-av', rsyncRoot + 'packages.riot.im/', pubDir,
-        ], {
-            stdio: 'inherit',
-        });
-        proc.on('exit', code => {
-            code ? reject(code) : resolve();
-        });
-    });
-}
-
 export function pushArtifacts(pubDir: string, rsyncRoot: string): Promise<void> {
     logger.info("Uploading artifacts...");
     return new Promise((resolve, reject) => {

--- a/src/debian.ts
+++ b/src/debian.ts
@@ -41,34 +41,6 @@ export async function setDebVersion(ver: string, templateFile: string, outFile: 
     logger.info("Version set to " + ver);
 }
 
-export function pullDebDatabase(debDir: string, rsyncRoot: string): Promise<void> {
-    logger.info("Pulling debian database...", rsyncRoot + 'debian/', debDir);
-    return new Promise((resolve, reject) => {
-        const proc = childProcess.spawn('rsync', [
-            '-av', '--delete', rsyncRoot + 'debian/', debDir,
-        ], {
-            stdio: 'inherit',
-        });
-        proc.on('exit', code => {
-            code ? reject(code) : resolve();
-        });
-    });
-}
-
-export function pushDebDatabase(debDir: string, rsyncRoot: string): Promise<void> {
-    logger.info("Pushing debian database...");
-    return new Promise((resolve, reject) => {
-        const proc = childProcess.spawn('rsync', [
-            '-av', '--delete', debDir + '/', rsyncRoot + 'debian',
-        ], {
-            stdio: 'inherit',
-        });
-        proc.on('exit', code => {
-            code ? reject(code) : resolve();
-        });
-    });
-}
-
 export async function addDeb(debDir: string, deb: string): Promise<void> {
     const targets = await getRepoTargets(debDir);
     logger.info("Adding " + deb + " for " + targets.join(', ') + "...");

--- a/src/desktop_develop.ts
+++ b/src/desktop_develop.ts
@@ -24,8 +24,8 @@ import Runner, { IRunner } from './runner';
 import DockerRunner from './docker_runner';
 import WindowsBuilder from './windows_builder';
 import { ENABLED_TARGETS, Target, TargetId, WindowsTarget } from './target';
-import { setDebVersion, pullDebDatabase, pushDebDatabase, addDeb } from './debian';
-import { getMatchingFilesInDir, pullArtifacts, pushArtifacts, copyAndLog, rm } from './artifacts';
+import { setDebVersion, addDeb } from './debian';
+import { getMatchingFilesInDir, pushArtifacts, copyAndLog, rm } from './artifacts';
 
 const DESKTOP_GIT_REPO = 'https://github.com/vector-im/element-desktop.git';
 const ELECTRON_BUILDER_CFG_FILE = 'electron-builder.json';
@@ -146,9 +146,6 @@ export default class DesktopDevelopBuilder {
 
         try {
             this.building = true;
-
-            // Sync all the artifacts from the server before we start
-            await pullArtifacts(this.pubDir, this.rsyncRoot);
 
             for (const target of toBuild) {
                 try {
@@ -314,11 +311,9 @@ export default class DesktopDevelopBuilder {
                 await pruneBuilds(path.join(this.appPubDir, 'update', 'macos'), /-mac.zip$/);
             }
         } else if (target.platform === 'linux') {
-            await pullDebDatabase(this.debDir, this.rsyncRoot);
             for (const f of await getMatchingFilesInDir(path.join(repoDir, 'dist'), /\.deb$/)) {
                 await addDeb(this.debDir, path.resolve(repoDir, 'dist', f));
             }
-            await pushDebDatabase(this.debDir, this.rsyncRoot);
         }
 
         logger.info("Removing build dir");

--- a/src/desktop_release.ts
+++ b/src/desktop_release.ts
@@ -24,8 +24,8 @@ import Runner, { IRunner } from './runner';
 import DockerRunner from './docker_runner';
 import WindowsBuilder from './windows_builder';
 import { ENABLED_TARGETS, Target, WindowsTarget } from './target';
-import { setDebVersion, pullDebDatabase, pushDebDatabase, addDeb } from './debian';
-import { getMatchingFilesInDir, pullArtifacts, pushArtifacts, copyAndLog, rm } from './artifacts';
+import { setDebVersion, addDeb } from './debian';
+import { getMatchingFilesInDir, pushArtifacts, copyAndLog, rm } from './artifacts';
 
 const DESKTOP_GIT_REPO = 'https://github.com/vector-im/element-desktop.git';
 const ELECTRON_BUILDER_CFG_FILE = 'electron-builder.json';
@@ -87,9 +87,6 @@ export default class DesktopReleaseBuilder {
 
         try {
             this.building = true;
-
-            // Sync all the artifacts from the server before we start
-            await pullArtifacts(this.pubDir, this.rsyncRoot);
 
             for (const target of toBuild) {
                 try {
@@ -269,11 +266,9 @@ export default class DesktopReleaseBuilder {
                 await fsProm.writeFile(latestPath, buildVersion);
             }
         } else if (target.platform === 'linux') {
-            await pullDebDatabase(this.debDir, this.rsyncRoot);
             for (const f of await getMatchingFilesInDir(path.join(repoDir, 'dist'), /\.deb$/)) {
                 await addDeb(this.debDir, path.resolve(repoDir, 'dist', f));
             }
-            await pushDebDatabase(this.debDir, this.rsyncRoot);
         }
 
         logger.info("Removing build dir");


### PR DESCRIPTION
This is now unnecessary because the build box is the only box writing
artifacts to the build server, so we can just consider whatever's on
the build box as authoritive and clobber whatever's on the server.

The reprepro database simlarly no longer needs to be synced to the server,
since there's only one thing writing to it: we can just keep the
database on the build box.

This should fix a whole multitude of failure modes where changes on
the build box get clobbered when it syncs from the server.