### PR TITLE
Build universal binary on mac

### DIFF
--- a/src/desktop_develop.ts
+++ b/src/desktop_develop.ts
@@ -262,54 +262,30 @@ export default class DesktopDevelopBuilder {
         logger.info("Build completed!");
 
         if (target.platform === 'darwin') {
-            await fsProm.mkdir(path.join(this.appPubDir, 'install', 'macos', target.arch), { recursive: true });
-            await fsProm.mkdir(path.join(this.appPubDir, 'update', 'macos', target.arch), { recursive: true });
+            await fsProm.mkdir(path.join(this.appPubDir, 'install', 'macos'), { recursive: true });
+            await fsProm.mkdir(path.join(this.appPubDir, 'update', 'macos'), { recursive: true });
 
             for (const f of await getMatchingFilesInDir(path.join(repoDir, 'dist'), /\.dmg$/)) {
                 await copyAndLog(
                     path.join(repoDir, 'dist', f),
                     // be consistent with windows and don't bother putting the version number
                     // in the installer
-                    path.join(this.appPubDir, 'install', 'macos', target.arch, 'Element Nightly.dmg'),
+                    path.join(this.appPubDir, 'install', 'macos', 'Element Nightly.dmg'),
                 );
             }
             for (const f of await getMatchingFilesInDir(path.join(repoDir, 'dist'), /-mac.zip$/)) {
                 await copyAndLog(
                     path.join(repoDir, 'dist', f),
-                    path.join(this.appPubDir, 'update', 'macos', target.arch, f),
+                    path.join(this.appPubDir, 'update', 'macos', f),
                 );
             }
 
-            const latestPath = path.join(this.appPubDir, 'update', 'macos', target.arch, 'latest');
+            const latestPath = path.join(this.appPubDir, 'update', 'macos', 'latest');
             logger.info('Write ' + buildVersion + ' -> ' + latestPath);
             await fsProm.writeFile(latestPath, buildVersion);
 
             // prune update packages (the installer will just overwrite each time)
-            await pruneBuilds(path.join(this.appPubDir, 'update', 'macos', target.arch), /-mac.zip$/);
-
-            // For backwards compat with older versions trying to update as well
-            // as existing links in the wild, we also copy the x64 version to
-            // the generic locations without the architecture.
-            if (target.arch === 'x64') {
-                for (const f of await getMatchingFilesInDir(path.join(repoDir, 'dist'), /\.dmg$/)) {
-                    await copyAndLog(
-                        path.join(repoDir, 'dist', f),
-                        // be consistent with windows and don't bother putting the version number
-                        // in the installer
-                        path.join(this.appPubDir, 'install', 'macos', 'Element Nightly.dmg'),
-                    );
-                }
-                for (const f of await getMatchingFilesInDir(path.join(repoDir, 'dist'), /-mac.zip$/)) {
-                    await copyAndLog(path.join(repoDir, 'dist', f), path.join(this.appPubDir, 'update', 'macos', f));
-                }
-
-                const latestPath = path.join(this.appPubDir, 'update', 'macos', 'latest');
-                logger.info('Write ' + buildVersion + ' -> ' + latestPath);
-                await fsProm.writeFile(latestPath, buildVersion);
-
-                // prune update packages (the installer will just overwrite each time)
-                await pruneBuilds(path.join(this.appPubDir, 'update', 'macos'), /-mac.zip$/);
-            }
+            await pruneBuilds(path.join(this.appPubDir, 'update', 'macos'), /-mac.zip$/);
         } else if (target.platform === 'linux') {
             for (const f of await getMatchingFilesInDir(path.join(repoDir, 'dist'), /\.deb$/)) {
                 await addDeb(this.debDir, path.resolve(repoDir, 'dist', f));
@@ -337,12 +313,21 @@ export default class DesktopDevelopBuilder {
         target: Target,
     ): Promise<void> {
         await runner.run('yarn', 'install');
-        await runner.run('yarn', 'run', 'hak', 'check', '--target', target.id);
         if (target.arch == 'universal') {
+            for (const subTarget of (target as UniversalTarget).subtargets) {
+                await runner.run('yarn', 'run', 'hak', 'check', '--target', subTarget.id);
+            }
             for (const subTarget of (target as UniversalTarget).subtargets) {
                 await runner.run('yarn', 'run', 'build:native', '--target', subTarget.id);
             }
+            const targetArgs = [];
+            for (const st of (target as UniversalTarget).subtargets) {
+                targetArgs.push('--target');
+                targetArgs.push(st.id);
+            }
+            await runner.run('yarn', 'run', 'hak', 'copy', ...targetArgs);
         } else {
+            await runner.run('yarn', 'run', 'hak', 'check', '--target', target.id);
             await runner.run('yarn', 'run', 'build:native', '--target', target.id);
         }
         await runner.run('yarn', 'run', 'fetch', 'develop', '-d', 'element.io/nightly');

--- a/src/desktop_release.ts
+++ b/src/desktop_release.ts
@@ -23,7 +23,7 @@ import logger from './logger';
 import Runner, { IRunner } from './runner';
 import DockerRunner from './docker_runner';
 import WindowsBuilder from './windows_builder';
-import { ENABLED_TARGETS, Target, WindowsTarget } from './target';
+import { ENABLED_TARGETS, Target, UniversalTarget, WindowsTarget } from './target';
 import { setDebVersion, addDeb } from './debian';
 import { getMatchingFilesInDir, pushArtifacts, copyAndLog, rm } from './artifacts';
 

--- a/src/target.ts
+++ b/src/target.ts
@@ -19,16 +19,17 @@ limitations under the License.
 // See https://doc.rust-lang.org/rustc/platform-support.html.
 export type TargetId =
     'aarch64-apple-darwin' |
+    'x86_64-apple-darwin' |
+    'universal-apple-darwin' |
     'i686-pc-windows-msvc' |
     'x86_64-pc-windows-msvc' |
-    'x86_64-apple-darwin' |
     'x86_64-unknown-linux-gnu';
 
 // Values are expected to match those used in `process.platform`.
 type Platform = 'darwin' | 'linux' | 'win32';
 
 // Values are expected to match those used in `process.arch`.
-type Arch = 'arm64' | 'ia32' | 'x64';
+type Arch = 'arm64' | 'ia32' | 'x64' | 'universal';
 
 // Values are expected to match those used by Visual Studio's `vcvarsall.bat`.
 // See https://docs.microsoft.com/cpp/build/building-on-the-command-line?view=msvc-160#vcvarsall-syntax
@@ -45,10 +46,31 @@ export type WindowsTarget = Target & {
     vcVarsArch: VcVarsArch;
 }
 
+export type UniversalTarget = Target & {
+    arch: 'universal',
+    subtargets: Target[],
+}
+
 const aarch64AppleDarwin: Target = {
     id: 'aarch64-apple-darwin',
     platform: 'darwin',
     arch: 'arm64',
+};
+
+const x8664AppleDarwin: Target = {
+    id: 'x86_64-apple-darwin',
+    platform: 'darwin',
+    arch: 'x64',
+};
+
+const universalAppleDarwin: UniversalTarget = {
+    id: 'universal-apple-darwin',
+    platform: 'darwin',
+    arch: 'universal',
+    subtargets: [
+        aarch64AppleDarwin,
+        x8664AppleDarwin,
+    ],
 };
 
 const i686PcWindowsMsvc: WindowsTarget = {
@@ -65,12 +87,6 @@ const x8664PcWindowsMsvc: WindowsTarget = {
     vcVarsArch: 'amd64',
 }
 
-const x8664AppleDarwin: Target = {
-    id: 'x86_64-apple-darwin',
-    platform: 'darwin',
-    arch: 'x64',
-};
-
 const x8664UnknownLinuxGnu: Target = {
     id: 'x86_64-unknown-linux-gnu',
     platform: 'linux',
@@ -79,17 +95,17 @@ const x8664UnknownLinuxGnu: Target = {
 
 export const TARGETS: Record<TargetId, Target> = {
     'aarch64-apple-darwin': aarch64AppleDarwin,
+    'x86_64-apple-darwin': x8664AppleDarwin,
+    'universal-apple-darwin': universalAppleDarwin,
     'i686-pc-windows-msvc': i686PcWindowsMsvc,
     'x86_64-pc-windows-msvc': x8664PcWindowsMsvc,
-    'x86_64-apple-darwin': x8664AppleDarwin,
     'x86_64-unknown-linux-gnu': x8664UnknownLinuxGnu,
 };
 
 // The set of targets we build by default, sorted by increasing complexity so
 // that we fail fast when the native host target fails.
 export const ENABLED_TARGETS: Target[] = [
-    TARGETS['x86_64-apple-darwin'],
-    TARGETS['aarch64-apple-darwin'],
+    TARGETS['universal-apple-darwin'],
     TARGETS['x86_64-unknown-linux-gnu'],
     TARGETS['x86_64-pc-windows-msvc'],
 ];


### PR DESCRIPTION
Splits targets into UniversalTarget which has subtargets, then builds native modules for each subtarget. Slightly abuses the fact that 'universal' is also the right thing to pass to electron-builder to make it fetch universal electron.

Copies to the arch-less paths for mac.