### PR TITLE
support building on more platforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "tsc"
   },
   "dependencies": {
-    "rimraf": "^3.0.2"
+    "rimraf": "^3.0.2",
+    "detect-libc": "^1.0.3"
   },
   "devDependencies": {
     "@types/node": "14",

--- a/src/target.ts
+++ b/src/target.ts
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { GLIBC, MUSL, family as processLibC } from "detect-libc"
+
 // We borrow Rust's target naming scheme as a way of expressing all target
 // details in a single string.
 // See https://doc.rust-lang.org/rustc/platform-support.html.
@@ -23,17 +25,27 @@ export type TargetId =
     'universal-apple-darwin' |
     'i686-pc-windows-msvc' |
     'x86_64-pc-windows-msvc' |
-    'x86_64-unknown-linux-gnu';
+    'i686-unknown-linux-musl' |
+    'i686-unknown-linux-gnu' |
+    'x86_64-unknown-linux-musl' |
+    'x86_64-unknown-linux-gnu' |
+    'aarch64-unknown-linux-musl' |
+    'aarch64-unknown-linux-gnu' |
+    'powerpc64le-unknown-linux-musl' |
+    'powerpc64le-unknown-linux-gnu';
 
 // Values are expected to match those used in `process.platform`.
 type Platform = 'darwin' | 'linux' | 'win32';
 
 // Values are expected to match those used in `process.arch`.
-type Arch = 'arm64' | 'ia32' | 'x64' | 'universal';
+type Arch = 'arm64' | 'ia32' | 'x64' | 'ppc64' | 'universal';
 
 // Values are expected to match those used by Visual Studio's `vcvarsall.bat`.
 // See https://docs.microsoft.com/cpp/build/building-on-the-command-line?view=msvc-160#vcvarsall-syntax
 type VcVarsArch = 'amd64' | 'arm64' | 'x86';
+
+// Values are expected to match those used in `detect-libc`.
+type LibC = GLIBC | MUSL;
 
 export type Target = {
     id: TargetId;
@@ -44,6 +56,11 @@ export type Target = {
 export type WindowsTarget = Target & {
     platform: 'win32';
     vcVarsArch: VcVarsArch;
+}
+
+export type LinuxTarget = Target & {
+    platform: 'linux';
+    libC: LibC;
 }
 
 export type UniversalTarget = Target & {
@@ -87,10 +104,60 @@ const x8664PcWindowsMsvc: WindowsTarget = {
     vcVarsArch: 'amd64',
 }
 
-const x8664UnknownLinuxGnu: Target = {
+const x8664UnknownLinuxGnu: LinuxTarget = {
     id: 'x86_64-unknown-linux-gnu',
     platform: 'linux',
     arch: 'x64',
+    libC: 'glibc',
+};
+
+const x8664UnknownLinuxMusl: LinuxTarget = {
+    id: 'x86_64-unknown-linux-musl',
+    platform: 'linux',
+    arch: 'x64',
+    libC: 'musl',
+};
+
+const i686UnknownLinuxGnu: LinuxTarget = {
+    id: 'i686-unknown-linux-gnu',
+    platform: 'linux',
+    arch: 'ia32',
+    libC: 'glibc',
+};
+
+const i686UnknownLinuxMusl: LinuxTarget = {
+    id: 'i686-unknown-linux-musl',
+    platform: 'linux',
+    arch: 'ia32',
+    libC: 'musl',
+};
+
+const aarch64UnknownLinuxGnu: LinuxTarget = {
+    id: 'aarch64-unknown-linux-gnu',
+    platform: 'linux',
+    arch: 'arm64',
+    libC: 'glibc',
+};
+
+const aarch64UnknownLinuxMusl: LinuxTarget = {
+    id: 'aarch64-unknown-linux-musl',
+    platform: 'linux',
+    arch: 'arm64',
+    libC: 'musl',
+};
+
+const powerpc64leUnknownLinuxGnu: LinuxTarget = {
+    id: 'powerpc64le-unknown-linux-gnu',
+    platform: 'linux',
+    arch: 'ppc64',
+    libC: 'glibc',
+};
+
+const powerpc64leUnknownLinuxMusl: LinuxTarget = {
+    id: 'powerpc64le-unknown-linux-musl',
+    platform: 'linux',
+    arch: 'ppc64',
+    libC: 'musl',
 };
 
 export const TARGETS: Record<TargetId, Target> = {
@@ -99,7 +166,14 @@ export const TARGETS: Record<TargetId, Target> = {
     'universal-apple-darwin': universalAppleDarwin,
     'i686-pc-windows-msvc': i686PcWindowsMsvc,
     'x86_64-pc-windows-msvc': x8664PcWindowsMsvc,
+    'i686-unknown-linux-musl': i686UnknownLinuxMusl,
+    'i686-unknown-linux-gnu': i686UnknownLinuxGnu,
+    'x86_64-unknown-linux-musl': x8664UnknownLinuxMusl,
     'x86_64-unknown-linux-gnu': x8664UnknownLinuxGnu,
+    'aarch64-unknown-linux-musl': aarch64UnknownLinuxMusl,
+    'aarch64-unknown-linux-gnu': aarch64UnknownLinuxGnu,
+    'powerpc64le-unknown-linux-musl': powerpc64leUnknownLinuxMusl,
+    'powerpc64le-unknown-linux-gnu': powerpc64leUnknownLinuxGnu,
 };
 
 // The set of targets we build by default, sorted by increasing complexity so
@@ -113,7 +187,11 @@ export const ENABLED_TARGETS: Target[] = [
 export function getHost(): Target {
     return Object.values(TARGETS).find(target => (
         target.platform === process.platform &&
-        target.arch === process.arch
+        target.arch === process.arch &&
+        (
+            process.platform !== 'linux' ||
+            (target as LinuxTarget).libC === processLibC
+        )
     ));
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -338,6 +338,11 @@ deep-is@^0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
+detect-libc@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
+  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
+
 diff@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"


### PR DESCRIPTION
This adds support for building on a lot more linux platforms. Supported
architectures now include x86_64, i686, powerpc64le and
aarch64. In addition to that, this adds the ability to use musl on each
of these as well, in addition to glibc.